### PR TITLE
fix pinch position in landscape

### DIFF
--- a/poco/utils/airtest/input.py
+++ b/poco/utils/airtest/input.py
@@ -108,11 +108,13 @@ class AirtestInput(InputInterface):
                 contact = e[2]
                 x, y = e[1]
                 pos = self.get_target_pos(x, y)
+                pos = current_device()._touch_point_by_orientation(pos)
                 me = DownEvent(pos, contact)
             elif t == 'm':
                 contact = e[2]
                 x, y = e[1]
                 pos = self.get_target_pos(x, y)
+                pos = current_device()._touch_point_by_orientation(pos)
                 me = MoveEvent(pos, contact)
             elif t == 'u':
                 contact = e[1]


### PR DESCRIPTION
I have a little trouble that pinch area go to offscreen when device is landscape.
This problem is the difference between touch pos and minitouch

This is experimental pull request.
I know _touch_point_by_orientation is desired private method.

I am very helped by this tool
I hope you find something useful.
Thanks.