### PR TITLE
Fix isVRSupported call method name

### DIFF
--- a/poco/drivers/unity3d/unity3d_poco.py
+++ b/poco/drivers/unity3d/unity3d_poco.py
@@ -18,7 +18,7 @@ class UnityVRSupport():
         self.client = client
         self.support_vr = False
         try:
-            self.support_vr = self.client.call("isVrSupported")
+            self.support_vr = self.client.call("isVRSupported")
         except InvalidOperationException:
             raise InvalidOperationException('VR not supported')
 


### PR DESCRIPTION
VR in method name is uppercase in poco-SDK ([PocoManager.cs](https://github.com/AirtestProject/Poco-SDK/blob/master/Unity3D/PocoManager.cs))
rpc.addRpcMethod("isVRSupported", vr_support.isVRSupported);