### PR TITLE
1.0.85

### DIFF
--- a/poco/drivers/android/uiautomation.py
+++ b/poco/drivers/android/uiautomation.py
@@ -181,11 +181,6 @@ class AndroidUiautomationPoco(Poco):
             p1 = 10081
 
         # start
-        if self._is_running('com.github.uiautomator'):
-            warnings.warn('{} should not run together with "uiautomator". "uiautomator" will be killed.'
-                          .format(self.__class__.__name__))
-            self.adb_client.shell(['am', 'force-stop', 'com.github.uiautomator'])
-
         ready = self._start_instrument(p0, force_restart=force_restart)
         if not ready:
             # 之前启动失败就卸载重装，现在改为尝试kill进程或卸载uiautomator
@@ -250,7 +245,7 @@ class AndroidUiautomationPoco(Poco):
             self._instrument_proc = None
 
         ready = False
-        self.adb_client.shell(['am', 'force-stop', PocoServicePackage])
+        # self.adb_client.shell(['am', 'force-stop', PocoServicePackage])
 
         # 启动instrument之前，先把主类activity启动起来，不然instrumentation可能失败
         self.adb_client.shell('am start -n {}/.TestActivity'.format(PocoServicePackage))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
 requests
 airtest
-hrpc>=1.0.5
+hrpc>=1.0.9
 websocket-client==0.48.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='pocoui',
-    version='1.0.84',
+    version='1.0.85',
     keywords="poco, automation test, ui automation",
     description='Poco cross-engine UI automated test framework.',
     long_description='Poco cross-engine UI automated test framework. 2018 present by NetEase Games',


### PR DESCRIPTION
## pocoservice.apk 改动

- 修复了1.0.84版本可能带来的新问题：假如poco(xx).click()时，当前页面不止一个节点会被筛选出来，并且正好第一个节点可能是不可见节点的话，会导致点击位置超出屏幕的报错
- 部分APP的某些页面可能使用了WebView控件，以前的版本无法抓取，现在能够抓取（并不能完全保证所有的WebView都可以拿到）
- UI树的层级结构多了一层，因此能够抓取到一些之前无法抓取的控件了
  - 例如部分手机的一些底部虚拟按钮、某些输入法的按键界面（如讯飞输入法）等
- 修复了一个筛选出列表后、再进行进一步条件筛选时可能会引发的报错
  - 例如，`poco(xx)[0].parent().exists()`执行正常，但是`poco(xx)[1].parent().exists()`就会报错
- 修复了部分手机可能拿到的节点信息未能实时刷新，导致运行失败的问题
  - 例如：某个列表从上往下滚动时，某个节点一开始不存在，但是后来滚动到了画面中心，此时拿到的节点信息可能依然是不存在，导致脚本报错（主要在部分机型上可能出现、以及如果手机在设置-显示-大小，设置为“大”的话，也可能导致此问题）
  - 此问题在1.0.84版本已经修复，但是带来了比较严重的性能问题，我们在这个版本做了优化，尽可能在刷新节点的同时保证了运行时的速度
- 去掉了当部分特殊节点无法被抓取到时的一个报错

## 其他改动

- 由于Android poco不能与`uiautomator`同时运行，之前的版本会在启动前强制做一些杀进程的操作，现在改为只有启动失败时，才尝试杀进程，加快启动速度
- `hrpc`提升至1.0.9版本，将一个在断开时可能出现的连接报错`hrpc.exceptions.TransportDisconnected: HTTPConnectionPool(host='127.0.0.1', port=11385): Max retries exceeded with url: /`进行了简单处理