### PR TITLE
v1.0.87

### DIFF
--- a/poco/drivers/android/uiautomation.py
+++ b/poco/drivers/android/uiautomation.py
@@ -11,7 +11,7 @@ import atexit
 
 from airtest.core.api import connect_device, device as current_device
 from airtest.core.android.ime import YosemiteIme
-from airtest.core.error import AdbShellError
+from airtest.core.error import AdbShellError, AirtestError
 
 from hrpc.client import RpcClient
 from hrpc.transport.http import HttpTransport
@@ -161,7 +161,12 @@ class AndroidUiautomationPoco(Poco):
             self.device_ip = self.device.get_ip_address()
 
         # save current top activity (@nullable)
-        current_top_activity_package = self.device.get_top_activity_name()
+        try:
+            current_top_activity_package = self.device.get_top_activity_name()
+        except AirtestError as e:
+            # 在一些极端情况下，可能获取不到top activity的信息
+            print(e)
+            current_top_activity_package = None
         if current_top_activity_package is not None:
             current_top_activity_package = current_top_activity_package.split('/')[0]
 

--- a/poco/drivers/ios/__init__.py
+++ b/poco/drivers/ios/__init__.py
@@ -41,9 +41,16 @@ class iosDumper(FrozenUIDumper):
         self.size = client.display_info["window_width"], client.display_info["window_height"]
 
     def dumpHierarchy(self, onlyVisibleNode=True):
-        switch_flag = False
-        if self.client.is_pad and self.client.orientation != 'PORTRAIT' and self.client.home_interface():
+        # 当使用了appium/WebDriverAgent时，ipad横屏且在桌面下，坐标需要按照竖屏坐标额外转换一次
+        # 判断条件如下：
+        # 当ios.using_ios_tagent有值、且为false，说明使用的是appium/WebDriverAgent
+        # airtest<=1.2.4时，没有ios.using_ios_tagent的值，说明也是用的appium/wda
+        if ((hasattr(self.client, "using_ios_tagent") and not self.client.using_ios_tagent) or
+            (not hasattr(self.client, "using_ios_tagent"))) \
+                and (self.client.is_pad and self.client.orientation != 'PORTRAIT' and self.client.home_interface()):
             switch_flag = True
+        else:
+            switch_flag = False
         jsonObj = self.client.driver.source(format='json')
         w, h = self.size
         if self.client.orientation in ['LANDSCAPE', 'UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT']:

--- a/poco/drivers/netease/internal.py
+++ b/poco/drivers/netease/internal.py
@@ -17,7 +17,7 @@ __author__ = 'lxn3032'
 
 class NeteasePocoAgent(PocoAgent):
     def __init__(self, hunter):
-        client = HunterRpcClient(hunter)
+        client = hunter.rpc
         client.set_timeout(25)
         remote_poco = client.remote('poco-uiautomation-framework-2')
 

--- a/poco/drivers/netease/internal.py
+++ b/poco/drivers/netease/internal.py
@@ -42,10 +42,10 @@ class NeteasePocoAgent(PocoAgent):
 
 class NeteasePoco(Poco):
     def __init__(self, process, hunter=None, **options):
-        apitoken = open_platform.get_api_token(process)
         if hunter:
             self._hunter = hunter
         else:
+            apitoken = open_platform.get_api_token(process)
             self._hunter = AirtestHunter(apitoken, process)
         agent = NeteasePocoAgent(self._hunter)
         super(NeteasePoco, self).__init__(agent, **options)

--- a/poco/proxy.py
+++ b/poco/proxy.py
@@ -696,6 +696,8 @@ class UIObjectProxy(object):
             self.poco.sleep_for_polling_interval()
             if time.time() - start > timeout:
                 raise PocoTargetTimeout('disappearance', self)
+            # 强制重新获取节点状态，避免节点已经存在、又消失后，这里不会刷新节点信息导致exists()永远为True的bug
+            self.invalidate()
 
     @refresh_when(PocoTargetRemovedException)
     def attr(self, name):
@@ -862,10 +864,22 @@ class UIObjectProxy(object):
     def invalidate(self):
         """
         Clear the flag to indicate to re-query or re-select the UI element(s) from hierarchy.
+
+        alias is refresh()
+
+        Example:
+            >>> a = poco(text="settings")
+            >>> print(a.exists())
+            >>> a.refresh()
+            >>> print(a.exists())
         """
 
         self._evaluated = False
         self._nodes = None
+
+    # refresh is alias of invalidate
+    # use poco(xxx).refresh() to force the UI element(s) to re-query
+    refresh = invalidate
 
     def _do_query(self, multiple=True, refresh=False):
         if not self._evaluated or refresh:

--- a/poco/proxy.py
+++ b/poco/proxy.py
@@ -871,6 +871,8 @@ class UIObjectProxy(object):
         if not self._evaluated or refresh:
             self._nodes = self.poco.agent.hierarchy.select(self.query, multiple)
             if len(self._nodes) == 0:
+                # 找不到节点时，将当前节点状态重置，强制下一次访问时重新查询一次节点信息
+                self.invalidate()
                 raise PocoNoSuchNodeException(self)
             self._evaluated = True
             self._query_multiple = multiple

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='pocoui',
-    version='1.0.85',
+    version='1.0.86',
     keywords="poco, automation test, ui automation",
     description='Poco cross-engine UI automated test framework.',
     long_description='Poco cross-engine UI automated test framework. 2018 present by NetEase Games',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='pocoui',
-    version='1.0.86',
+    version='1.0.87',
     keywords="poco, automation test, ui automation",
     description='Poco cross-engine UI automated test framework.',
     long_description='Poco cross-engine UI automated test framework. 2018 present by NetEase Games',


### PR DESCRIPTION
主要改动如下：
- 在初始化Android poco时，假如get_top_activity获取失败了，就暂时忽略掉，因为本步骤不是必须的
- 网易内网版本支持了hunter2
- 支持了即将更新的iOS-Tagent的最新版本
- 新增了一个`refresh()`接口，用于强制刷新节点信息