### PR TITLE
Fix the exception handling for cases where socket.gaierror is thrown.

### DIFF
--- a/poco/drivers/std/__init__.py
+++ b/poco/drivers/std/__init__.py
@@ -96,7 +96,7 @@ class StdPoco(Poco):
         else:
             try:
                 ip = self.device.get_ip_address()
-            except AttributeError:
+            except:
                 try:
                     ip = socket.gethostbyname(socket.gethostname())
                 except socket.gaierror:


### PR DESCRIPTION
I encountered an issue where the line "ip = self.device.get_ip_address()" was throwing a socket.gaierror exception and not being handled properly, causing the program to exit.

And I fixed this problem.

By the way, it seems that the socket.gaierror exception occurs in a Windows environment when a DNS suffix is set and the "Use this connection's DNS suffix in DNS registration" option is not checked in the network connection. Checking the "Use this connection's DNS suffix in DNS registration" option will prevent this issue from occurring.

Environment:
- Windows 10
- Python 3.9.13