### PR TITLE
fix: poco daemon thread created multiple times

### DIFF
--- a/poco/drivers/android/uiautomation.py
+++ b/poco/drivers/android/uiautomation.py
@@ -200,6 +200,8 @@ class AndroidUiautomationPoco(Poco):
             if not ready:
                 raise RuntimeError("unable to launch AndroidUiautomationPoco")
         if ready:
+            if hasattr(self, '_keep_running_thread') and self._keep_running_thread.is_alive():
+                self._keep_running_thread.stop()
             # 首次启动成功后，在后台线程里监控这个进程的状态，保持让它不退出
             self._keep_running_thread = KeepRunningInstrumentationThread(self, p0)
             self._keep_running_thread.start()


### PR DESCRIPTION
- https://github.com/AirtestProject/Poco/issues/577

- 在启动新的 _keep_running_thread 之前,首先检查是否已经存在,如果存在则先关闭之前的线程,然后再启动一个新的线程。