### PR TITLE
V1.0.92

### DIFF
--- a/DocBuilder/index.rst
+++ b/DocBuilder/index.rst
@@ -238,7 +238,7 @@ UI hierarchy.
     from poco.drivers.unity3d import UnityPoco as Poco
 
     poco = Poco()
-    ui = poco.agent.hierarchy.dump()
+    ui = poco.dump()  # equivalent to poco.agent.hierarchy.dump()
     print(json.dumps(ui, indent=4))
 
 

--- a/poco/drivers/android/uiautomation.py
+++ b/poco/drivers/android/uiautomation.py
@@ -178,9 +178,11 @@ class AndroidUiautomationPoco(Poco):
         self._install_service()
 
         # forward
+        self.forward_list = []
         if using_proxy:
             p0, _ = self.adb_client.setup_forward("tcp:10080")
             p1, _ = self.adb_client.setup_forward("tcp:10081")
+            self.forward_list.extend(["tcp:%s" % p0, "tcp:%s" % p1])
         else:
             p0 = 10080
             p1 = 10081
@@ -323,7 +325,13 @@ class AndroidUiautomationPoco(Poco):
         print('[pocoservice.apk] stopping PocoService')
         self._keep_running_thread.stop()
         self._keep_running_thread.join(3)
+        self.remove_forwards()
         self.adb_client.shell(['am', 'force-stop', PocoServicePackage])
+
+    def remove_forwards(self):
+        for p in self.forward_list:
+            self.adb_client.remove_forward(p)
+        self.forward_list = []
 
 
 class AndroidUiautomationHelper(object):

--- a/poco/pocofw.py
+++ b/poco/pocofw.py
@@ -505,3 +505,13 @@ class Poco(PocoAccelerationMixin):
         '''
         self._agent.input.use_render_resolution = use
         self._agent.input.render_resolution = resolution
+
+    def dump(self):
+        """
+        Dump the current UI tree of the target device. The output format depends on the agent implementation.
+
+        Returns:
+            :obj:`str`: base64 encoded UI tree data
+        """
+
+        return self.agent.hierarchy.dump()

--- a/poco/pocofw.py
+++ b/poco/pocofw.py
@@ -257,7 +257,9 @@ class Poco(PocoAccelerationMixin):
         raise NotImplementedError
 
     def double_click(self, pos):
-        raise NotImplementedError
+        ret = self.agent.input.double_click(pos[0], pos[1])
+        self.wait_stable()
+        return ret
 
     def swipe(self, p1, p2=None, direction=None, duration=2.0):
         """

--- a/poco/proxy.py
+++ b/poco/proxy.py
@@ -882,7 +882,7 @@ class UIObjectProxy(object):
     def _do_query(self, multiple=True, refresh=False):
         if not self._evaluated or refresh:
             self._nodes = self.poco.agent.hierarchy.select(self.query, multiple)
-            if len(self._nodes) == 0:
+            if not self._nodes or len(self._nodes) == 0:
                 # 找不到节点时，将当前节点状态重置，强制下一次访问时重新查询一次节点信息
                 self.invalidate()
                 raise PocoNoSuchNodeException(self)

--- a/poco/proxy.py
+++ b/poco/proxy.py
@@ -269,7 +269,7 @@ class UIObjectProxy(object):
                 nodes = []
         else:
             nodes = self._nodes
-        return len(nodes)
+        return len(nodes) if nodes else 0
 
     def __iter__(self):
         """

--- a/poco/proxy.py
+++ b/poco/proxy.py
@@ -191,7 +191,7 @@ class UIObjectProxy(object):
 
     def parent(self):
         """
-        Select the direct child(ren) from the UI element(s) given by the query expression, see ``QueryCondition`` for
+        Select the direct parent from the UI element(s) given by the query expression, see ``QueryCondition`` for
         more details about the selectors.
 
         Warnings:

--- a/poco/sdk/interfaces/input.py
+++ b/poco/sdk/interfaces/input.py
@@ -23,6 +23,16 @@ class InputInterface(object):
         """
 
         raise NotImplementedError
+    def double_click(self, x, y):
+        """
+        Perform click action as simulated input on target device. Coordinates arguments are all in range of 0~1.
+
+        Args:
+            y (:obj:`float`): y-coordinate
+            x (:obj:`float`): x-coordinate
+        """
+
+        raise NotImplementedError
 
     def swipe(self, x1, y1, x2, y2, duration):
         """

--- a/poco/sdk/interfaces/input.py
+++ b/poco/sdk/interfaces/input.py
@@ -23,6 +23,7 @@ class InputInterface(object):
         """
 
         raise NotImplementedError
+
     def double_click(self, x, y):
         """
         Perform click action as simulated input on target device. Coordinates arguments are all in range of 0~1.

--- a/poco/utils/airtest/input.py
+++ b/poco/utils/airtest/input.py
@@ -3,7 +3,7 @@
 from functools import wraps
 
 from airtest.core.api import device as current_device
-from airtest.core.api import touch, swipe,double_click
+from airtest.core.api import touch, swipe, double_click
 from airtest.core.helper import device_platform, logwrap
 from poco.sdk.interfaces.input import InputInterface
 
@@ -83,8 +83,6 @@ class AirtestInput(InputInterface):
     def double_click(self, x, y):
         pos = self.get_target_pos(x, y)
         double_click(pos)
-
-
 
     def swipe(self, x1, y1, x2, y2, duration=2.0):
         if duration <= 0:

--- a/poco/utils/airtest/input.py
+++ b/poco/utils/airtest/input.py
@@ -3,7 +3,7 @@
 from functools import wraps
 
 from airtest.core.api import device as current_device
-from airtest.core.api import touch, swipe
+from airtest.core.api import touch, swipe,double_click
 from airtest.core.helper import device_platform, logwrap
 from poco.sdk.interfaces.input import InputInterface
 
@@ -79,6 +79,12 @@ class AirtestInput(InputInterface):
     def click(self, x, y):
         pos = self.get_target_pos(x, y)
         touch(pos, duration=self.default_touch_down_duration)
+
+    def double_click(self, x, y):
+        pos = self.get_target_pos(x, y)
+        double_click(pos)
+
+
 
     def swipe(self, x1, y1, x2, y2, duration=2.0):
         if duration <= 0:

--- a/poco/utils/simplerpc/jsonrpc/dispatcher.py
+++ b/poco/utils/simplerpc/jsonrpc/dispatcher.py
@@ -3,10 +3,13 @@
 For usage examples see :meth:`Dispatcher.add_method`
 
 """
-import collections
+try:
+    from collections import MutableMapping
+except AttributeError:
+    from collections.abc import MutableMapping
 
 
-class Dispatcher(collections.MutableMapping):
+class Dispatcher(MutableMapping):
 
     """ Dictionary like object which maps method_name to method."""
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='pocoui',
-    version='1.0.91',
+    version='1.0.92',
     keywords="poco, automation test, ui automation",
     description='Poco cross-engine UI automated test framework.',
     long_description='Poco cross-engine UI automated test framework. 2018 present by NetEase Games',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='pocoui',
-    version='1.0.89',
+    version='1.0.90',
     keywords="poco, automation test, ui automation",
     description='Poco cross-engine UI automated test framework.',
     long_description='Poco cross-engine UI automated test framework. 2018 present by NetEase Games',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='pocoui',
-    version='1.0.90',
+    version='1.0.91',
     keywords="poco, automation test, ui automation",
     description='Poco cross-engine UI automated test framework.',
     long_description='Poco cross-engine UI automated test framework. 2018 present by NetEase Games',


### PR DESCRIPTION
Add:

1. 新增 `poco.dump()` 接口，效果等同于之前的`poco.agent.hierarchy.dump()`接口，让调用更简单
2. 新增 `poco.double_click()`接口
3. 在android poco主动调用`stop_running`时，释放申请的端口号
4. 更新了PocoService.apk，对一些机型兼容性更好

* * *

1. Added `poco.dump()` interface, which has the same effect as the previous `poco.agent.hierarchy.dump()` interface, making the call easier
2. Added `poco.double_click()` interface
3. When android poco actively calls `stop_running`, release the requested port number
4. Updated PocoService.apk, which has better compatibility with some models.