### PR TITLE
set timeout to 5s

### DIFF
--- a/poco/drivers/android/uiautomation.py
+++ b/poco/drivers/android/uiautomation.py
@@ -9,7 +9,6 @@ import warnings
 import threading
 import atexit
 
-from airtest.core.api import connect_device, device as current_device
 from airtest.core.android.ime import YosemiteIme
 from airtest.core.error import AdbShellError, AirtestError
 
@@ -22,6 +21,7 @@ from poco.sdk.interfaces.screen import ScreenInterface
 from poco.utils.hrpc.hierarchy import RemotePocoHierarchy
 from poco.utils.airtest.input import AirtestInput
 from poco.utils import six
+from poco.utils.device import default_device
 from poco.drivers.android.utils.installation import install, uninstall
 
 __all__ = ['AndroidUiautomationPoco', 'AndroidUiautomationHelper']
@@ -150,9 +150,7 @@ class AndroidUiautomationPoco(Poco):
         if options.get('screenshot_each_action') is False:
             self.screenshot_each_action = False
 
-        self.device = device or current_device()
-        if not self.device:
-            self.device = connect_device("Android:///")
+        self.device = device or default_device()
 
         self.adb_client = self.device.adb
         if using_proxy:

--- a/poco/drivers/cocosjs/__init__.py
+++ b/poco/drivers/cocosjs/__init__.py
@@ -17,6 +17,7 @@ else:
     from urlparse import urlparse
 
 from airtest.core.api import connect_device, device as current_device
+from poco.utils.device import default_device
 from airtest.core.helper import device_platform
 
 
@@ -26,25 +27,23 @@ DEFAULT_ADDR = ('localhost', DEFAULT_PORT)
 
 
 class CocosJsPocoAgent(PocoAgent):
-    def __init__(self, port, device=None):
-        self.device = device or current_device()
-        if not self.device:
-            self.device = connect_device("Android:///")
+    def __init__(self, port, device=None, ip=None):
+        if ip is None or ip == "localhost":
+            self.device = device or default_device()
 
-        platform_name = device_platform(self.device)
-        if platform_name == 'Android':
-            local_port, _ = self.device.adb.setup_forward('tcp:{}'.format(port))
-            ip = self.device.adb.host or 'localhost'
-            port = local_port
-        elif platform_name == 'IOS':
-            # Note: ios is now support for now.
-            # ip = device.get_ip_address()
-            # use iproxy first
-            ip = 'localhost'
-            local_port, _ = self.device.instruct_helper.setup_proxy(port)
-            port = local_port
-        else:
-            ip = self.device.get_ip_address()
+            platform_name = device_platform(self.device)
+            if platform_name == 'Android':
+                local_port, _ = self.device.adb.setup_forward('tcp:{}'.format(port))
+                ip = self.device.adb.host or 'localhost'
+                port = local_port
+            elif platform_name == 'IOS':
+                port, _ = self.device.setup_forward(port)
+                if self.device.is_local_device:
+                    ip = 'localhost'
+                else:
+                    ip = self.device.ip
+            else:
+                ip = self.device.get_ip_address()
 
         # transport
         self.conn = WebSocketClient('ws://{}:{}'.format(ip, port))
@@ -90,11 +89,12 @@ class CocosJsPoco(Poco):
                 port = urlparse(addr).port
                 if not port:
                     raise ValueError
+                ip = urlparse(addr).hostname
         except ValueError:
             raise ValueError('Argument "addr" should be a tuple[2] or string format. e.g. '
                              '["localhost", 5003] or "ws://localhost:5003". Got {}'.format(repr(addr)))
 
-        agent = CocosJsPocoAgent(port, device)
+        agent = CocosJsPocoAgent(port, device, ip=ip)
         if 'action_interval' not in options:
             options['action_interval'] = 0.5
         super(CocosJsPoco, self).__init__(agent, **options)

--- a/poco/drivers/ue4/ue4_poco.py
+++ b/poco/drivers/ue4/ue4_poco.py
@@ -23,4 +23,4 @@ class UE4Poco(StdPoco):
         if dev is None and connect_default_device and not current_device():
             dev = connect_device("Android:///")
 
-        super(UE4Poco, self).__init__(addr[1], dev, **options)
+        super(UE4Poco, self).__init__(addr[1], dev, ip=addr[0], **options)

--- a/poco/drivers/unity3d/unity3d_poco.py
+++ b/poco/drivers/unity3d/unity3d_poco.py
@@ -77,6 +77,6 @@ class UnityPoco(StdPoco):
             # can apply auto detection in the future
             dev = connect_device("Android:///")
 
-        super(UnityPoco, self).__init__(addr[1], dev, **options)
+        super(UnityPoco, self).__init__(addr[1], dev, ip=addr[0], **options)
         # If some devices fail to initialize, the UI tree cannot be obtained
         # self.vr = UnityVRSupport(self.agent.rpc)

--- a/poco/utils/device.py
+++ b/poco/utils/device.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import
 
 from airtest.core.device import Device
+from airtest.core.api import connect_device, device as current_device
+from airtest.core.error import NoDeviceError
 
 
 class VirtualDevice(Device):
@@ -18,3 +20,15 @@ class VirtualDevice(Device):
 
     def get_ip_address(self):
         return self.ip
+
+
+def default_device():
+    """
+    Get default device, if no device connected, connect to first android device.
+
+    :return:
+    """
+    try:
+        return current_device()
+    except NoDeviceError:
+        return connect_device('Android:///')

--- a/poco/utils/simplerpc/transport/tcp/safetcp.py
+++ b/poco/utils/simplerpc/transport/tcp/safetcp.py
@@ -2,7 +2,7 @@
 import socket
 
 
-DEFAULT_TIMEOUT = 2
+DEFAULT_TIMEOUT = 5
 DEFAULT_SIZE = 4096
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='pocoui',
-    version='1.0.92',
+    version='1.0.93',
     keywords="poco, automation test, ui automation",
     description='Poco cross-engine UI automated test framework.',
     long_description='Poco cross-engine UI automated test framework. 2018 present by NetEase Games',


### PR DESCRIPTION
1. poco初始化时，原先是默认使用设备IP，现在支持传入指定IP连接，例如: `poco = UnityPoco(addr=(ip, port))`
2. 如果未连接设备，默认尝试连接当前的第一台安卓设备